### PR TITLE
Responsive Design

### DIFF
--- a/maquetado/index.html
+++ b/maquetado/index.html
@@ -11,7 +11,7 @@
 <body>
   <nav class="nav">
     <img class="nav-logo" src="images/wolox_logo.svg" alt="Wolox's Logo">
-    <h2 class="nav-item">Developer Tools</h2>
+    <h2 class="nav-item dev-tools">Developer Tools</h2>
   </nav>
 
   <div class="wrapper">

--- a/maquetado/index.html
+++ b/maquetado/index.html
@@ -11,7 +11,7 @@
 <body>
   <nav class="nav">
     <img class="nav-logo" src="images/wolox_logo.svg" alt="Wolox's Logo">
-    <h2 class="nav-item dev-tools">Developer Tools</h2>
+    <h2 class="nav-item">Developer Tools</h2>
   </nav>
 
   <div class="wrapper">

--- a/maquetado/scss/_navbar.scss
+++ b/maquetado/scss/_navbar.scss
@@ -18,3 +18,9 @@
     font-size: $text-big;
   }
 }
+
+@media screen and (max-width: 1024px) {
+  .dev-tools {
+    display: none;
+  }
+}

--- a/maquetado/scss/_navbar.scss
+++ b/maquetado/scss/_navbar.scss
@@ -20,7 +20,7 @@
 }
 
 @media screen and (max-width: 1024px) {
-  .dev-tools {
+  .nav-item {
     display: none;
   }
 }

--- a/maquetado/scss/_tech.scss
+++ b/maquetado/scss/_tech.scss
@@ -20,7 +20,7 @@
     font-size: $text-big;
     margin-bottom: 10px;
   }
-  
+
   &-logo {
     height: $tech-logo-size;
     margin-bottom: 10px;
@@ -50,8 +50,8 @@
 
 @media screen and (max-width: 1024px) {
   .tech-list {
-    grid-template-columns: $tech-width;
     grid-gap: 40px;
+    grid-template-columns: $tech-width;
   }
 
   .tech {

--- a/maquetado/scss/_tech.scss
+++ b/maquetado/scss/_tech.scss
@@ -47,3 +47,19 @@
   justify-content: center;
   margin-bottom: 100px;
 }
+
+@media screen and (max-width: 1024px) {
+  .tech-list {
+    grid-template-columns: $tech-width;
+    grid-gap: 40px;
+  }
+
+  .tech {
+    border-bottom: 2px solid $green;
+
+    &:first-child {
+      border-right: none;
+      grid-row: auto;
+    }
+  }
+}

--- a/maquetado/scss/_title.scss
+++ b/maquetado/scss/_title.scss
@@ -3,7 +3,7 @@
   display: flex;
   font-size: $text-big;
   height: $text-decoration-height;
-  margin: 20px;
+  margin-bottom: 20px;
 
   &::before {
     background: url('images/triangle.svg') no-repeat;


### PR DESCRIPTION
## Summary

- Added responsive design with breakpoint of `1024px`

## Screenshots

<img width="372" alt="Screen Shot 2019-07-22 at 10 31 39 AM" src="https://user-images.githubusercontent.com/22043902/61645290-ef6eb980-ac6b-11e9-9439-3bb4f7698540.png">

## Trello Card

https://trello.com/c/IIJQQIH2

